### PR TITLE
Use SecureValue for access key and Secret key

### DIFF
--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -254,8 +254,8 @@ AWSSignature4DynamicValue.identifier = 'com.shigeoka.PawExtensions.AWSSignature4
 AWSSignature4DynamicValue.title = 'AWS Signature 4 Auth'
 AWSSignature4DynamicValue.help = 'https://github.com/badslug/Paw-AWSSignature4DynamicValue'
 AWSSignature4DynamicValue.inputs = [
-      DynamicValueInput('key', 'AWS Access Key', 'String'),
-      DynamicValueInput('secret', 'AWS Secret Key', 'String'),
+      DynamicValueInput('key', 'AWS Access Key', 'SecureValue'),
+      DynamicValueInput('secret', 'AWS Secret Key', 'SecureValue'),
       DynamicValueInput('region', 'AWS Region (us-east-1)', 'String'),
       DynamicValueInput('service', 'AWS Service (execute-api)', 'String'),
   ]


### PR DESCRIPTION
Since Paw 2.3 paw supports a new field type: SecureValue

this will by default encrypt the value entered in the field. (the user is able to disable this on a per field basis)
