### PR TITLE
Removed double URL encoding from canonicalization of URL parameters.

### DIFF
--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -71,9 +71,12 @@ function getParametersString(request, search) {
      * equals sign ( = ) (ASCII character 61), even if the parameter value is
      * empty.
      * Separate the name-value pairs with an ampersand ( & ) (ASCII code 38).
+     *
+     * NOTE: Paw already URL encodes parameters before passing them to this 
+     * extension.
      */
     var stringParams = params.map(function(pair) {
-      return encodeURIComponent(pair[0]) + '=' + encodeURIComponent(pair[1])
+      return pair[0] + '=' + pair[1]
     })
     return stringParams.join('&')
   }


### PR DESCRIPTION
This is my first time using a pull request on Github--please be gentle!

The extension was working great for me until I used a URL parameter that required URI encoding. Through a little troubleshooting, I discovered Paw already URL encodes parameters before the extension gets them. As a result, the code was working fine when URL encoding produced the same output, but on parameters that actually were encoded, it would produce the wrong canonical string and signature.

To be 100% correct, it'd likely be better to have the code undo Paw's URL encoding and re-do it according to the sig v4 process, but this fixed my issue so I didn't want to let perfect be the enemy of good.

In my case, what triggered it is I was returning an S3 ListObjects v2 NextContinuationToken, which included an equals sign.