### PR TITLE
Fix syntax error

### DIFF
--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -211,7 +211,7 @@ var AWSSignature4DynamicValue = function() {
         if (names) {
             names.forEach(function(name) {
                 var lower = name.toLowerCase()
-                if (lower !== 'x-amz-date' && lower.startsWith('x-amz-') {
+                if (lower !== 'x-amz-date' && lower.startsWith('x-amz-')) {
                     signedHeaders += ';'+lower
                     headers += lower + ':' + request.getHeaderByName(name, false) + '\n'
                 }

--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -207,7 +207,7 @@ var AWSSignature4DynamicValue = function() {
         // Search for other signed headers to include. We will assume any headers that begin with X-Amz-<*> will be included
         var signedHeaders = 'host;x-amz-date'
         var headers = '' // The actual headers to sign
-        var names = request.getHeaderNames()
+        var names = request.getHeadersNames()
         if (names) {
             names.forEach(function(name) {
                 var lower = name.toLowerCase()


### PR DESCRIPTION
this was introduced in https://github.com/badslug/Paw-AWSSignature4DynamicValue/pull/6/commits/47f53240d7e1d4607b614a4ab6027db5473a03e9

~This might also be the reason why the push to Paw did not work properly https://github.com/badslug/Paw-AWSSignature4DynamicValue/issues/10~