### PR TITLE
Fix duplicated use of variable names in signed header lookup

### DIFF
--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -206,9 +206,10 @@ var AWSSignature4DynamicValue = function() {
         
         // Search for other signed headers to include. We will assume any headers that begin with X-Amz-<*> will be included
         var signedHeaders = 'host;x-amz-date'
-        var headers = request.getHeadersArray()
-        if (headers) {
-          headers.forEach(function(header) {
+        var headers = '' // The actual headers to sign
+        var headersArray = request.getHeadersArray()
+        if (headersArray) {
+          headersArray.forEach(function(header) {
             var lower = header.name.getEvaluatedString().toLowerCase()
             if (lower !== 'x-amz-date' && lower.startsWith('x-amz-')) {
               signedHeaders += ';'+lower


### PR DESCRIPTION
The fix for the cyclical dependencies (https://github.com/badslug/Paw-AWSSignature4DynamicValue/commit/b123fccfb6be500c3263f941cdeb6d714576f947) introduced another small bug.

Due to a duplicated use of variables the headers wich are used to sign the request look like this:
```
Header<Authorization>,Header<X-Amz-Date>,Header<x-amz-security-token>x-amz-security-token:yourtoken
```

@badslug @JonathanMontane Please have a look