### PR TITLE
Encode ',' in path before signing

### DIFF
--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -232,7 +232,7 @@ var AWSSignature4DynamicValue = function() {
         
         // Step 1
         var canonical = request.method + '\n' +
-            uri.pathname + '\n' +
+            uri.pathname.replace(',', '%2C') + '\n' +
             getParametersString(request, uri.search) + '\n' +
             canonicalHeaders.join('\n') + '\n' +
             '\n' +


### PR DESCRIPTION
I've seen an issue in signing when searching multiple indices (ie. `/index1,index2/_search`).  AWS indicates the canonical hash should be `/index1%2Cindex2/_search`. 