### PR TITLE
Fix host header

### DIFF
--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -212,7 +212,7 @@ var AWSSignature4DynamicValue = function() {
           })
         }
 
-        headers['host'] = uri.hostname.toLowerCase();
+        headers['host'] = uri.host.toLowerCase();
 
         if (!headers['x-amz-date']) {
           headers['x-amz-date'] = daytime;

--- a/AWSSignature4DynamicValue.js
+++ b/AWSSignature4DynamicValue.js
@@ -183,10 +183,6 @@ var AWSSignature4DynamicValue = function() {
     this.evaluate = function(context) {
         var request = context.getCurrentRequest()
         var uri = getLocation(request.url)
-        var opts = {
-            path: uri.pathname,
-            host: uri.hostname,
-        }
         var region = this.region || 'us-east-1'
         var service = this.service || 'execute-api'
 


### PR DESCRIPTION
Use URI host (includes port if set) instead of hostname, which matches value that Paw uses by default. Otherwise, the `host` header used for signature generation doesn't match the value Paw sends.